### PR TITLE
New Serverspec Test

### DIFF
--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'spec::default' do
+
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+  
+  it 'does something' do
+    skip 'Replace this with meaningful tests'
+  end
+
+end
+
+describe file('/var/run/mongodb') do
+  it { should be_directory }
+  it { should be_owned_by 'mongod' }
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
Added a simple Chef Serverspec test to demonstrate how it works. The directory structure is what the command 'chef generate cookbook <cookbook_name>' generates. I think Test Kitchen relies on this structure to find the tests.

In the role-mongodb-configserver directory, run the following:

kitchen list                                            # Lists the available instance names in Test Kitchen
kitchen converge <instance name>     # Deploy the cookbook to a node. This is also useful in checking 
                                                            # for errors. Use one of the instance names from the output of 
                                                            # kitchen list
kitchen list                                           # The Last Action column should now be 'Converged'
kitchen verify                                       # Run serverspec tests
kitchen list                                           # The Last Action column should now be 'Verified'

Note the provisioner in .kitchen.yml for role-mongodb-configserver is chef zero. Most of the other cookbooks seem to be using chef solo. Need to check if this works with chef solo.
